### PR TITLE
Improve language and structure of PSP-22

### DIFF
--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -813,29 +813,28 @@ type Balance = u128;
 ```
 
 ### Errors
-Suggested methods revert the transaction and return Result with Error from this list:
+The suggested methods revert the transaction and return a `Result` type with one of the following Error enum's:
 
-```
-/// PSP22Error 
+```rust
+enum PSP22Error {
+    /// Custom error type for cases in which an implementation adds its own restrictions.
+    Custom(String),
+    /// Returned if not enough balance to fulfill a request is available.
+    InsufficientBalance,
+    /// Returned if not enough allowance to fulfill a request is available.
+    InsufficientAllowance,
+    /// Returned if recipient's address is zero.
+    ZeroRecipientAddress,
+    /// Returned if sender's address is zero.
+    ZeroSenderAddress,
+    /// Returned if a safe transfer check fails (e.g. if the receiving contract does not accept tokens).
+    SafeTransferCheckFailed(String),
+}
 
-/// Custom error type for cases if writer of traits added own restrictions
-Custom(String),
-/// Returned if not enough balance to fulfill a request is available.
-InsufficientBalance,
-/// Returned if not enough allowance to fulfill a request is available.
-InsufficientAllowance,
-/// Returned if recipient's address is zero.
-ZeroRecipientAddress,
-/// Returned if sender's address is zero.
-ZeroSenderAddress,
-/// Returned if safe transfer check fails (see _do_safe_transfer_check() in PSP22 trait)
-SafeTransferCheckFailed(String),
-
-
-/// PSP22ReceiverError 
-
-/// Returned if a transfer is rejected.
-TransferRejected(String),
+enum PSP22ReceiverError {
+    /// Returned if a transfer is rejected.
+    TransferRejected(String),
+}
 ```
 
 ## Copyright

--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -11,14 +11,14 @@
 
 A standard fungible token interface for WASM contracts.
 
-This proposal aims to define the standard fungible token in WASM smart contracts, just like [EIP-20](https://github.com/ethereum/EIPs/edit/master/EIPS/eip-20.md) for Ethereum ecosystem.
+This proposal aims to define the standard fungible token interface for WASM smart contracts, just like [EIP-20](https://github.com/ethereum/EIPs/edit/master/EIPS/eip-20.md) for the Ethereum ecosystem.
 
 ## Importance
-Currently, while there is no standard, every contract will have different signature. Thus, no interoperability is possible. This proposal aims to resolve that by having one **interface** that shares the
+Currently, while there is no standard, every contract will have different a signature. Thus, no interoperability is possible. This proposal aims to resolve that by defining one **interface** that shares the
 same **ABI** between all implementations.
 
 ## Implementation
-Example of ink! implementation:
+Example of an ink! implementation:
 
 - [OpenBrush](https://github.com/Supercolony-net/openbrush-contracts/blob/main/contracts/token/psp22/src/traits.rs)
 
@@ -26,16 +26,16 @@ Example of ink! implementation:
 A standard interface allows any tokens on Polkadot/Kusama to be re-used by other applications: from wallets to decentralized exchanges.
 
 
-## Motivation for having a standard separate from ERC20
-Due to different nature of WASM smart contracts and the difference between EVM and `pallet-contract` in substrate, the standard should have specific rules and methods,
+## Motivation for having a standard separate from ERC-20
+Due to the different nature of WASM smart contracts and the difference between EVM and `pallet-contracts` in Substrate, this standard proposal has specific rules and methods,
 therefore PSP-22 differs from ERC-20 in its implementation.
 
-Also, this standard proposal defines an extensive method list in the interface. Unlike ERC20, it includes `increase_allowance` & `decrease_allowance`, and defines metadata fields as part of a separate interface.
-Another difference is that it has `PSP22Receiver` interface, and `before_received` method is called at the end of transfer if the recipient is a contract.
+Also, this standard proposal defines an extensive method list in the interface. Unlike ERC-20, it includes `increase_allowance` & `decrease_allowance`, and defines metadata fields as part of a separate interface.
+Another difference is that it has the `PSP22Receiver` interface, and `before_received` method is called at the end of transfer if the recipient is a contract.
 
 # This standard is at ABI level
 
-As `pallet-contract` in Substrate can execute any WASM contracts, we should not restrain this standard to only Rust & ink! Framework, so that it can be used by any language/framework that compile to WASM.
+The `contracts` pallet in Substrate can execute any WASM contract that implements a defined API; we should not restrain this standard to only Rust and the ink! language, but make it possible to be implemented by any language/framework that compiles to WASM.
 
 ## Specification
 1. [Interface](#Interface)
@@ -45,7 +45,7 @@ As `pallet-contract` in Substrate can execute any WASM contracts, we should not 
 
 ### Interface
 
-#### PSP22 is an interface of Fungible Token Standard
+#### PSP-22 is an interface of Fungible Token Standard
 
 ##### **total_supply**() -> Balance
 Selector: `0x162df8c2` - first 4 bytes of `blake2b_256("PSP22::total_supply")`

--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -593,7 +593,7 @@ Selector: `0xfda6f1a9` - first 4 bytes of `blake2b_256("PSP22Receiver::before_re
 
 ### Events
 
-##### Transfer 
+#### Transfer 
 When a contract creates (mints) new tokens, `from` will be `None`.
 When a contract deletes (burns) tokens, `to` will be `None`.
 ```json
@@ -640,7 +640,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
 }
 ```
 
-#### Approval
+### Approval
 ```json
 {
   "args": [
@@ -686,7 +686,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
 }
 ```
 
-### Types
+## Types
 ```rust
 // AccountId is a 32 bytes Array, like in Substrate-based blockchains.
 type AccountId = [u8; 32];
@@ -694,7 +694,8 @@ type AccountId = [u8; 32];
 // `u128` must be enough to cover most of the use-cases of standard tokens.
 type Balance = u128;
 ```
-#### Return types
+
+### Return types
 ```json
 {
   "types": {

--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -4,7 +4,7 @@
 - **Authors:** Green Baneling <green.baneling@supercolony.net>, Markian <markian@supercolony.net>, Pierre <pierre.ossun@supercolony.net>, Sven <sven.seven@supercolony.net>, Varg <varg.vikernes@supercolony.net>
 - **Status:** Call For Feedback
 - **Created:** 2021-06-19
-- **Reference Implementation:** [OpenBrush](https://github.com/Supercolony-net/openbrush-contracts/blob/main/contracts/token/psp20/traits.rs)
+- **Reference Implementation:** [OpenBrush](https://github.com/Supercolony-net/openbrush-contracts/blob/main/contracts/token/psp22/src/traits.rs)
 
 
 ## Summary

--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -47,7 +47,7 @@ The `contracts` pallet in Substrate can execute any WASM contract that implement
 
 #### PSP-22 is an interface of Fungible Token Standard
 
-##### **total_supply**() -> Balance
+##### **`total_supply`**`() -> Balance`
 Selector: `0x162df8c2` - first 4 bytes of `blake2b_256("PSP22::total_supply")`
 ```json
 {

--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -1,4 +1,4 @@
-# PSP-22 Fungible Token Standard in WASM
+# Fungible Token Standard for Substrate's `contracts` pallet
 
 - **PSP Number:** 22
 - **Authors:** Green Baneling <green.baneling@supercolony.net>, Markian <markian@supercolony.net>, Pierre <pierre.ossun@supercolony.net>, Sven <sven.seven@supercolony.net>, Varg <varg.vikernes@supercolony.net>
@@ -9,7 +9,7 @@
 
 ## Summary
 
-A standard fungible token interface for WASM contracts.
+A standard for a Fungible Token Interface for WASM contracts.
 
 This proposal aims to define the standard fungible token interface for WASM smart contracts, just like [EIP-20](https://github.com/ethereum/EIPs/edit/master/EIPS/eip-20.md) for the Ethereum ecosystem.
 
@@ -38,16 +38,16 @@ Another difference is that it has the `PSP22Receiver` interface, and `before_rec
 The `contracts` pallet in Substrate can execute any WASM contract that implements a defined API; we should not restrain this standard to only Rust and the ink! language, but make it possible to be implemented by any language/framework that compiles to WASM.
 
 ## Specification
-1. [Interface](#Interface)
+1. [Interfaces](#Interfaces)
 2. [Events](#Events)
 3. [Types](#Types)
 4. [Errors](#Errors)
 
-### Interface
+### Interfaces
 
-#### PSP-22 is an interface of Fungible Token Standard
+#### PSP-22 Interface for a Fungible Token Standard
 
-##### **`total_supply`**`() -> Balance`
+##### **total_supply()** ➔ Balance
 Selector: `0x162df8c2` - first 4 bytes of `blake2b_256("PSP22::total_supply")`
 ```json
 {
@@ -70,7 +70,7 @@ Selector: `0x162df8c2` - first 4 bytes of `blake2b_256("PSP22::total_supply")`
 }
 ```
 
-##### **balance_of**(owner: AccountId) -> Balance
+##### **balance_of**(owner: AccountId) ➔ Balance
 Selector: `0x6568382f` - first 4 bytes of `blake2b_256("PSP22::balance_of")`
 ```json
 {
@@ -105,7 +105,7 @@ Selector: `0x6568382f` - first 4 bytes of `blake2b_256("PSP22::balance_of")`
 }
 ```
 
-##### **allowance**(owner: AccountId, spender: AccountId) -> Balance
+##### **allowance**(owner: AccountId, spender: AccountId) ➔ Balance
 Selector: `0x4d47d921` - first 4 bytes of `blake2b_256("PSP22::allowance")`
 ```json
 {
@@ -149,7 +149,7 @@ Selector: `0x4d47d921` - first 4 bytes of `blake2b_256("PSP22::allowance")`
 }
 ```
 
-##### **transfer**(to: AccountId, value: Balance, data: [u8]) -> Result<(), PSP22Error>
+##### **transfer**(to: AccountId, value: Balance, data: [u8]) ➔ Result<(), PSP22Error>
 Selector: `0xdb20f9f5` - first 4 bytes of `blake2b_256("PSP22::transfer")`
 ```json
 {
@@ -212,7 +212,7 @@ Selector: `0xdb20f9f5` - first 4 bytes of `blake2b_256("PSP22::transfer")`
 }
 ```
 
-##### **transfer_from**(from: AccountId, to: AccountId, value: Balance, data: [u8]) -> Result<(), PSP22Error>
+##### **transfer_from**(from: AccountId, to: AccountId, value: Balance, data: [u8]) ➔ Result<(), PSP22Error>
 Selector: `0x54b3c76e` - first 4 bytes of `blake2b_256("PSP22::transfer_from")`
 ```json
 {
@@ -290,7 +290,7 @@ Selector: `0x54b3c76e` - first 4 bytes of `blake2b_256("PSP22::transfer_from")`
 }
 ```
 
-##### **approve**(spender: AccountId, value: Balance) -> Result<(), PSP22Error>
+##### **approve**(spender: AccountId, value: Balance) ➔ Result<(), PSP22Error>
 Selector: `0xb20f1bbd` - first 4 bytes of `blake2b_256("PSP22::approve")`
 ```json
 {
@@ -344,7 +344,7 @@ Selector: `0xb20f1bbd` - first 4 bytes of `blake2b_256("PSP22::approve")`
 
 ```
 
-##### **increase_allowance**(spender: AccountId, delta_value: Balance) -> Result<(), PSP22Error>
+##### **increase_allowance**(spender: AccountId, delta_value: Balance) ➔ Result<(), PSP22Error>
 Selector: `0x96d6b57a` - first 4 bytes of `blake2b_256("PSP22::increase_allowance")`
 ```json
 {
@@ -394,7 +394,7 @@ Selector: `0x96d6b57a` - first 4 bytes of `blake2b_256("PSP22::increase_allowanc
 }
 ```
 
-##### **decrease_allowance**(spender: AccountId, delta_value: Balance) -> Result<(), PSP22Error>
+##### **decrease_allowance**(spender: AccountId, delta_value: Balance) ➔ Result<(), PSP22Error>
 Selector: `0xfecb57d5` - first 4 bytes of `blake2b_256("PSP22::decrease_allowance")`
 ```json
 {
@@ -448,9 +448,9 @@ Selector: `0xfecb57d5` - first 4 bytes of `blake2b_256("PSP22::decrease_allowanc
 ```
 
 #### PSP22Metadata 
-PSP22Metadata is an optional interface of metadata for Fungible Token Standard
+`PSP22Metadata` is an optional interface for metadata for this Fungible Token Standard.
 
-##### **token_name**() -> Option<String>
+##### **token_name**() ➔ Option<String>
 Selector: `0x3d261bd4` - first 4 bytes of `blake2b_256("PSP22Metadata::token_name")`
 ```json
 {
@@ -473,7 +473,7 @@ Selector: `0x3d261bd4` - first 4 bytes of `blake2b_256("PSP22Metadata::token_nam
 }
 ```
 
-##### **token_symbol**() -> Option<String>
+##### **token_symbol**() ➔ Option<String>
 Selector: `0x34205be5` - first 4 bytes of `blake2b_256("PSP22Metadata::token_symbol")`
 ```json
 {
@@ -496,7 +496,7 @@ Selector: `0x34205be5` - first 4 bytes of `blake2b_256("PSP22Metadata::token_sym
 }
 ```
 
-##### **token_decimals**() -> u8
+##### **token_decimals**() ➔ u8
 Selector: `0x7271b782` - first 4 bytes of `blake2b_256("PSP22Metadata::token_decimals")`
 ```json
 {
@@ -520,10 +520,10 @@ Selector: `0x7271b782` - first 4 bytes of `blake2b_256("PSP22Metadata::token_dec
 ```
 
 #### PSP22Receiver
-PSP22Receiver is an interface for any contract that wants to support safe transfers from PSP22 token smart contracts to avoid unexpected tokens on balance of contract.
-This method is called before transfer to ensure the recipient of the tokens acknowledges receipt.
+`PSP22Receiver` is an interface for any contract that wants to support safe transfers from a PSP-22 token smart contract to avoid unexpected tokens in the balance of contract.
+This method is called before a transfer to ensure the recipient of the tokens acknowledges the receipt.
 
-##### **before_received**(&mut self, operator: AccountId, from: AccountId, value: Balance, data: [u8]) -> Result<(), PSP22ReceiverError>
+##### **before_received**(&mut self, operator: AccountId, from: AccountId, value: Balance, data: [u8]) ➔ Result<(), PSP22ReceiverError>
 Selector: `0xfda6f1a9` - first 4 bytes of `blake2b_256("PSP22Receiver::before_received")`
 ```json
 {
@@ -592,8 +592,8 @@ Selector: `0xfda6f1a9` - first 4 bytes of `blake2b_256("PSP22Receiver::before_re
 ### Events
 
 ##### Transfer 
-When a contract creates (mints) new tokens, `from` will be `None`
-When a contract deletes (burns) tokens, `to` will be `None`
+When a contract creates (mints) new tokens, `from` will be `None`.
+When a contract deletes (burns) tokens, `to` will be `None`.
 ```json
 {
   "args": [
@@ -688,6 +688,7 @@ When a contract deletes (burns) tokens, `to` will be `None`
 ```rust
 // AccountId is a 32 bytes Array, like in Substrate-based blockchains.
 type AccountId = [u8; 32];
+
 // `u128` must be enough to cover most of the use-cases of standard tokens.
 type Balance = u128;
 ```
@@ -814,7 +815,7 @@ type Balance = u128;
 ### Errors
 Suggested methods revert the transaction and return Result with Error from this list:
 
-```rust
+```
 /// PSP22Error 
 
 /// Custom error type for cases if writer of traits added own restrictions
@@ -839,5 +840,5 @@ TransferRejected(String),
 
 ## Copyright
 
-Each PSP must be labeled as placed in the
+This PSP is placed in the
 [public domain](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -53,7 +53,7 @@ Selector: `0x162df8c2` - first 4 bytes of `blake2b_256("PSP22::total_supply")`
 {
   "args": [],
   "docs": [
-    " Returns the total token supply."
+    "Returns the total token supply."
   ],
   "mutates": false,
   "name": [
@@ -86,9 +86,9 @@ Selector: `0x6568382f` - first 4 bytes of `blake2b_256("PSP22::balance_of")`
     }
   ],
   "docs": [
-    " Returns the account Balance for the specified `owner`.",
+    "Returns the account balance for the specified `owner`.",
     "",
-    " Returns `0` if the account is non-existent."
+    "Returns `0` if the account is non-existent."
   ],
   "mutates": false,
   "name": [
@@ -130,9 +130,9 @@ Selector: `0x4d47d921` - first 4 bytes of `blake2b_256("PSP22::allowance")`
     }
   ],
   "docs": [
-    " Returns the amount which `spender` is still allowed to withdraw from `owner`.",
+    "Returns the amount which `spender` is still allowed to withdraw from `owner`.",
     "",
-    " Returns `0` if no allowance has been set `0`."
+    "Returns `0` if no allowance has been set `0`."
   ],
   "mutates": false,
   "name": [
@@ -183,19 +183,19 @@ Selector: `0xdb20f9f5` - first 4 bytes of `blake2b_256("PSP22::transfer")`
     }
   ],
   "docs": [
-    " Transfers `value` amount of tokens from the caller's account to account `to`",
-    " with additional `data` in unspecified format.",
+    "Transfers `value` amount of tokens from the caller's account to account `to`",
+    "with additional `data` in unspecified format.",
     "",
-    " On success a `Transfer` event is emitted.",
+    "On success a `Transfer` event is emitted.",
     "",
-    " # Errors",
+    "# Errors",
     "",
-    " Reverts with error `InsufficientBalance` if there are not enough tokens on",
-    " the caller's account Balance.",
+    "Reverts with error `InsufficientBalance` if there are not enough tokens on",
+    "the caller's account Balance.",
     "",
-    " Reverts with error `ZeroSenderAddress` if sender's address is zero.",
+    "Reverts with error `ZeroSenderAddress` if sender's address is zero.",
     "",
-    " Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
+    "Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
   ],
   "mutates": true,
   "name": [
@@ -255,25 +255,25 @@ Selector: `0x54b3c76e` - first 4 bytes of `blake2b_256("PSP22::transfer_from")`
     }
   ],
   "docs": [
-    " Transfers `value` tokens on the behalf of `from` to the account `to`",
-    " with additional `data` in unspecified format.",
+    "Transfers `value` tokens on the behalf of `from` to the account `to`",
+    "with additional `data` in unspecified format.",
     "",
-    " This can be used to allow a contract to transfer tokens on ones behalf and/or",
-    " to charge fees in sub-currencies, for example.",
+    "This can be used to allow a contract to transfer tokens on ones behalf and/or",
+    "to charge fees in sub-currencies, for example.",
     "",
-    " On success a `Transfer` and `Approval` events are emitted.",
+    "On success a `Transfer` and `Approval` events are emitted.",
     "",
-    " # Errors",
+    "# Errors",
     "",
-    " Reverts with error `InsufficientAllowance` if there are not enough tokens allowed",
-    " for the caller to withdraw from `from`.",
+    "Reverts with error `InsufficientAllowance` if there are not enough tokens allowed",
+    "for the caller to withdraw from `from`.",
     "",
-    " Reverts with error `InsufficientBalance` if there are not enough tokens on",
-    " the the account Balance of `from`.",
+    "Reverts with error `InsufficientBalance` if there are not enough tokens on",
+    "the the account Balance of `from`.",
     "",
-    " Reverts with error `ZeroSenderAddress` if sender's address is zero.",
+    "Reverts with error `ZeroSenderAddress` if sender's address is zero.",
     "",
-    " Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
+    "Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
   ],
   "mutates": true,
   "name": [
@@ -315,18 +315,18 @@ Selector: `0xb20f1bbd` - first 4 bytes of `blake2b_256("PSP22::approve")`
     }
   ],
   "docs": [
-    " Allows `spender` to withdraw from the caller's account multiple times, up to",
-    " the `value` amount.",
+    "Allows `spender` to withdraw from the caller's account multiple times, up to",
+    "the `value` amount.",
     "",
-    " If this function is called again it overwrites the current allowance with `value`.",
+    "If this function is called again it overwrites the current allowance with `value`.",
     "",
-    " An `Approval` event is emitted.",
+    "An `Approval` event is emitted.",
     "",
-    " # Errors",
+    "# Errors",
     "",
-    " Reverts with error `ZeroSenderAddress` if sender's address is zero.",
+    "Reverts with error `ZeroSenderAddress` if sender's address is zero.",
     "",
-    " Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
+    "Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
   ],
   "mutates": true,
   "name": [
@@ -369,15 +369,15 @@ Selector: `0x96d6b57a` - first 4 bytes of `blake2b_256("PSP22::increase_allowanc
     }
   ],
   "docs": [
-    " Atomically increases the allowance granted to `spender` by the caller.",
+    "Atomically increases the allowance granted to `spender` by the caller.",
     "",
-    " An `Approval` event is emitted.",
+    "An `Approval` event is emitted.",
     "",
-    " # Errors",
+    "# Errors",
     "",
-    " Reverts with error `ZeroSenderAddress` if sender's address is zero.",
+    "Reverts with error `ZeroSenderAddress` if sender's address is zero.",
     "",
-    " Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
+    "Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
   ],
   "mutates": true,
   "name": [
@@ -419,18 +419,18 @@ Selector: `0xfecb57d5` - first 4 bytes of `blake2b_256("PSP22::decrease_allowanc
     }
   ],
   "docs": [
-    " Atomically decreases the allowance granted to `spender` by the caller.",
+    "Atomically decreases the allowance granted to `spender` by the caller.",
     "",
-    " An `Approval` event is emitted.",
+    "An `Approval` event is emitted.",
     "",
-    " # Errors",
+    "# Errors",
     "",
-    " Reverts with error `InsufficientAllowance` if there are not enough tokens allowed",
-    " by owner for `spender`.",
+    "Reverts with error `InsufficientAllowance` if there are not enough tokens allowed",
+    "by owner for `spender`.",
     "",
-    " Reverts with error `ZeroSenderAddress` if sender's address is zero.",
+    "Reverts with error `ZeroSenderAddress` if sender's address is zero.",
     "",
-    " Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
+    "Reverts with error `ZeroRecipientAddress` if recipient's address is zero."
   ],
   "mutates": true,
   "name": [
@@ -456,7 +456,7 @@ Selector: `0x3d261bd4` - first 4 bytes of `blake2b_256("PSP22Metadata::token_nam
 {
   "args": [],
   "docs": [
-    " Returns the token name."
+    "Returns the token name."
   ],
   "mutates": false,
   "name": [
@@ -479,7 +479,7 @@ Selector: `0x34205be5` - first 4 bytes of `blake2b_256("PSP22Metadata::token_sym
 {
   "args": [],
   "docs": [
-    " Returns the token symbol."
+    "Returns the token symbol."
   ],
   "mutates": false,
   "name": [
@@ -502,7 +502,7 @@ Selector: `0x7271b782` - first 4 bytes of `blake2b_256("PSP22Metadata::token_dec
 {
   "args": [],
   "docs": [
-    " Returns the token decimals."
+    "Returns the token decimals."
   ],
   "mutates": false,
   "name": [
@@ -566,13 +566,13 @@ Selector: `0xfda6f1a9` - first 4 bytes of `blake2b_256("PSP22Receiver::before_re
     }
   ],
   "docs": [
-    " Ensures that the smart contract allows reception of PSP22 token(s).",
-    " Returns `Ok(())` if the contract allows the reception of the token(s) and Error `TransferRejected(String))` otherwise.",
+    "Ensures that the smart contract allows reception of PSP22 token(s).",
+    "Returns `Ok(())` if the contract allows the reception of the token(s) and Error `TransferRejected(String))` otherwise.",
     "",
-    " This method will get called on every transfer to check whether the recipient in `transfer` is a contract, and if it is,",
-    " does it accept tokens. This is done to prevent contracts from locking tokens forever.",
+    "This method will get called on every transfer to check whether the recipient in `transfer` is a contract, and if it is,",
+    "does it accept tokens. This is done to prevent contracts from locking tokens forever.",
     "",
-    " This method does not throw. Returns `PSP22ReceiverError` if the contract does not accept the tokens."
+    "This method does not throw. Returns `PSP22ReceiverError` if the contract does not accept the tokens."
   ],
   "mutates": true,
   "name": [
@@ -632,7 +632,7 @@ When a contract deletes (burns) tokens, `to` will be `None`
     }
   ],
   "docs": [
-    " Event emitted when a token transfer occurs."
+    "Event emitted when a token transfer occurs."
   ],
   "name": "Transfer"
 }
@@ -677,8 +677,8 @@ When a contract deletes (burns) tokens, `to` will be `None`
     }
   ],
   "docs": [
-    " Event emitted when an approval occurs that `spender` is allowed to withdraw",
-    " up to the amount of `value` tokens from `owner`."
+    "Event emitted when an approval occurs that `spender` is allowed to withdraw",
+    "up to the amount of `value` tokens from `owner`."
   ],
   "name": "Approval"
 }
@@ -686,9 +686,9 @@ When a contract deletes (burns) tokens, `to` will be `None`
 
 ### Types
 ```rust
-// AccountId is 32 bytes array, like in substrate-based blockchains.
+// AccountId is a 32 bytes Array, like in Substrate-based blockchains.
 type AccountId = [u8; 32];
-// u128 must be enough to cover most of the use cases of standard token.
+// `u128` must be enough to cover most of the use-cases of standard tokens.
 type Balance = u128;
 ```
 #### Return types
@@ -815,26 +815,26 @@ type Balance = u128;
 Suggested methods revert the transaction and return Result with Error from this list:
 
 ```rust
- /// PSP22Error 
- 
- /// Custom error type for cases if writer of traits added own restrictions
- Custom(String),
- /// Returned if not enough balance to fulfill a request is available.
- InsufficientBalance,
- /// Returned if not enough allowance to fulfill a request is available.
- InsufficientAllowance,
- /// Returned if recipient's address is zero.
- ZeroRecipientAddress,
- /// Returned if sender's address is zero.
- ZeroSenderAddress,
- /// Returned if safe transfer check fails (see _do_safe_transfer_check() in PSP22 trait)
- SafeTransferCheckFailed(String),
+/// PSP22Error 
+
+/// Custom error type for cases if writer of traits added own restrictions
+Custom(String),
+/// Returned if not enough balance to fulfill a request is available.
+InsufficientBalance,
+/// Returned if not enough allowance to fulfill a request is available.
+InsufficientAllowance,
+/// Returned if recipient's address is zero.
+ZeroRecipientAddress,
+/// Returned if sender's address is zero.
+ZeroSenderAddress,
+/// Returned if safe transfer check fails (see _do_safe_transfer_check() in PSP22 trait)
+SafeTransferCheckFailed(String),
 
 
- /// PSP22ReceiverError 
- 
- /// Returned if a transfer is rejected.
- TransferRejected(String),
+/// PSP22ReceiverError 
+
+/// Returned if a transfer is rejected.
+TransferRejected(String),
 ```
 
 ## Copyright

--- a/PSPs/drafts/psp-22.md
+++ b/PSPs/drafts/psp-22.md
@@ -1,4 +1,4 @@
-# Fungible Token Standard for Substrate's `contracts` pallet
+# Fungible Token Standard for WebAssembly smart contracts
 
 - **PSP Number:** 22
 - **Authors:** Green Baneling <green.baneling@supercolony.net>, Markian <markian@supercolony.net>, Pierre <pierre.ossun@supercolony.net>, Sven <sven.seven@supercolony.net>, Varg <varg.vikernes@supercolony.net>
@@ -9,33 +9,32 @@
 
 ## Summary
 
-A standard for a Fungible Token Interface for WASM contracts.
+A standard for a fungible token interface for WebAssembly smart contracts.
 
-This proposal aims to define the standard fungible token interface for WASM smart contracts, just like [EIP-20](https://github.com/ethereum/EIPs/edit/master/EIPS/eip-20.md) for the Ethereum ecosystem.
+This proposal aims to define the standard fungible token interface for WebAssembly smart contracts, just like [EIP-20](https://github.com/ethereum/EIPs/edit/master/EIPS/eip-20.md) for the Ethereum ecosystem.
 
-## Importance
+## Motivation
+
 Currently, while there is no standard, every contract will have different a signature. Thus, no interoperability is possible. This proposal aims to resolve that by defining one **interface** that shares the
 same **ABI** between all implementations.
 
-## Implementation
-Example of an ink! implementation:
+A standard interface allows any token on Polkadot/Kusama to be re-used by other applications: from wallets to decentralized exchanges.
 
-- [OpenBrush](https://github.com/Supercolony-net/openbrush-contracts/blob/main/contracts/token/psp22/src/traits.rs)
+## Implementations
+Examples of implementations:
 
-## Motivation
-A standard interface allows any tokens on Polkadot/Kusama to be re-used by other applications: from wallets to decentralized exchanges.
-
+- [OpenBrush](https://github.com/Supercolony-net/openbrush-contracts/blob/main/contracts/token/psp22/src/traits.rs), written in [ink!](https://github.com/paritytech/ink).
 
 ## Motivation for having a standard separate from ERC-20
-Due to the different nature of WASM smart contracts and the difference between EVM and `pallet-contracts` in Substrate, this standard proposal has specific rules and methods,
+Due to the different nature of WebAssembly smart contracts and the difference between EVM and the [`contracts` pallet](https://github.com/paritytech/substrate/tree/master/frame/contracts) in Substrate, this standard proposal has specific rules and methods,
 therefore PSP-22 differs from ERC-20 in its implementation.
 
-Also, this standard proposal defines an extensive method list in the interface. Unlike ERC-20, it includes `increase_allowance` & `decrease_allowance`, and defines metadata fields as part of a separate interface.
-Another difference is that it has the `PSP22Receiver` interface, and `before_received` method is called at the end of transfer if the recipient is a contract.
+Also, this standard proposal defines an extensive method list in the interface. Unlike ERC-20, it includes `increase_allowance` and `decrease_allowance`, and defines metadata fields as part of a separate interface.
+Another difference is that it has the `PSP22Receiver` interface, and the `before_received` method is called at the end of transfer if the recipient is a contract.
 
 # This standard is at ABI level
 
-The `contracts` pallet in Substrate can execute any WASM contract that implements a defined API; we should not restrain this standard to only Rust and the ink! language, but make it possible to be implemented by any language/framework that compiles to WASM.
+Substrate's [`contracts` pallet](https://github.com/paritytech/substrate/tree/master/frame/contracts) can execute any WebAssembly contract that implements its defined API; we do not want to restrain this standard to only Rust and [the ink! language](https://github.com/paritytech/ink), but make it possible to be implemented by any language/framework that compiles to WebAssembly.
 
 ## Specification
 1. [Interfaces](#Interfaces)
@@ -45,7 +44,9 @@ The `contracts` pallet in Substrate can execute any WASM contract that implement
 
 ### Interfaces
 
-#### PSP-22 Interface for a Fungible Token Standard
+#### PSP-22 Interface
+
+This section defines the required interface for this standard.
 
 ##### **total_supply()** ➔ Balance
 Selector: `0x162df8c2` - first 4 bytes of `blake2b_256("PSP22::total_supply")`
@@ -448,7 +449,8 @@ Selector: `0xfecb57d5` - first 4 bytes of `blake2b_256("PSP22::decrease_allowanc
 ```
 
 #### PSP22Metadata 
-`PSP22Metadata` is an optional interface for metadata for this Fungible Token Standard.
+
+`PSP22Metadata` is an optional interface for metadata for this fungible token standard.
 
 ##### **token_name**() ➔ Option<String>
 Selector: `0x3d261bd4` - first 4 bytes of `blake2b_256("PSP22Metadata::token_name")`
@@ -813,7 +815,7 @@ type Balance = u128;
 ```
 
 ### Errors
-The suggested methods revert the transaction and return a `Result` type with one of the following Error enum's:
+The suggested methods revert the transaction and return a `Result` type with one of the following error enum's:
 
 ```rust
 enum PSP22Error {
@@ -839,5 +841,4 @@ enum PSP22ReceiverError {
 
 ## Copyright
 
-This PSP is placed in the
-[public domain](https://creativecommons.org/publicdomain/zero/1.0/).
+This PSP is placed in the [public domain](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
[Preview here](https://github.com/cmichi/PSPs/blob/cmichi-improve-form-and-language-psp-22/PSPs/drafts/psp-22.md).

@Noc2 I went through the PSP and did some editing. No content was changed, I just improved the language and structure and made everything more consistent.

In general, I think there's still room for improvement. Maybe SCALE-encoding should be mentioned there. 

@themarkian @xgreenx To me it's unclear if the standard is supposed to be an interface for (a) the ABI of any WebAssembly smart contract or (b) a standard for Substrate's `contracts` pallet. This is something that should be clarified.