### PR TITLE
Update MessageResult in ABIs

### DIFF
--- a/PSPs/psp-22.md
+++ b/PSPs/psp-22.md
@@ -61,7 +61,8 @@ Selector: `0x162df8c2` - first 4 bytes of `blake2b_256("PSP22::total_supply")`
   ],
   "returnType": {
     "displayName": [
-      "Balance"
+      "ink",
+      "MessageResult"
     ],
     "type": "Balance"
   },
@@ -96,7 +97,8 @@ Selector: `0x6568382f` - first 4 bytes of `blake2b_256("PSP22::balance_of")`
   ],
   "returnType": {
     "displayName": [
-      "Balance"
+      "ink",
+      "MessageResult"
     ],
     "type": "Balance"
   },
@@ -140,7 +142,8 @@ Selector: `0x4d47d921` - first 4 bytes of `blake2b_256("PSP22::allowance")`
   ],
   "returnType": {
     "displayName": [
-      "Balance"
+      "ink",
+      "MessageResult"
     ],
     "type": "Balance"
   },
@@ -204,7 +207,8 @@ Selector: `0xdb20f9f5` - first 4 bytes of `blake2b_256("PSP22::transfer")`
   ],
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -282,7 +286,8 @@ Selector: `0x54b3c76e` - first 4 bytes of `blake2b_256("PSP22::transfer_from")`
   ],
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -335,7 +340,8 @@ Selector: `0xb20f1bbd` - first 4 bytes of `blake2b_256("PSP22::approve")`
   ],
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -386,7 +392,8 @@ Selector: `0x96d6b57a` - first 4 bytes of `blake2b_256("PSP22::increase_allowanc
   ],
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -439,7 +446,8 @@ Selector: `0xfecb57d5` - first 4 bytes of `blake2b_256("PSP22::decrease_allowanc
   ],
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -447,7 +455,7 @@ Selector: `0xfecb57d5` - first 4 bytes of `blake2b_256("PSP22::decrease_allowanc
 }
 ```
 
-#### PSP22Metadata 
+#### PSP22Metadata
 
 `PSP22Metadata` is an optional interface for metadata for this fungible token standard.
 
@@ -522,7 +530,7 @@ Selector: `0x7271b782` - first 4 bytes of `blake2b_256("PSP22Metadata::token_dec
 
 ### Events
 
-#### Transfer 
+#### Transfer
 When a contract creates (mints) new tokens, `from` will be `None`.
 When a contract deletes (burns) tokens, `to` will be `None`.
 ```json

--- a/PSPs/psp-34.md
+++ b/PSPs/psp-34.md
@@ -110,7 +110,7 @@ Selector: `0x1168624d` - first 4 bytes of `blake2b_256("PSP34::owner_of")`
       "label": "id",
       "type": {
         "displayName": [
-           "Id"
+          "Id"
         ],
         "type": "Id"
       }
@@ -124,7 +124,8 @@ Selector: `0x1168624d` - first 4 bytes of `blake2b_256("PSP34::owner_of")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Option"
+      "ink",
+      "MessageResult"
     ],
     "type": "Option<AccountId>"
   },
@@ -174,7 +175,8 @@ Selector: `0x4790f55a` - first 4 bytes of `blake2b_256("PSP34::allowance")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "bool"
+      "ink",
+      "MessageResult"
     ],
     "type": "bool"
   },
@@ -232,7 +234,8 @@ Selector: `0x1932a8b0` - first 4 bytes of `blake2b_256("PSP34::approve")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -291,7 +294,8 @@ Selector: `0x3128d61b` - first 4 bytes of `blake2b_256("PSP34::transfer")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -311,7 +315,8 @@ Selector: `0x628413fe` - first 4 bytes of `blake2b_256("PSP34::total_supply")`
   "label": "PSP34::total_supply",
   "returnType": {
     "displayName": [
-      "Balance"
+      "ink",
+      "MessageResult"
     ],
     "type": "Balance"
   },
@@ -360,7 +365,8 @@ Selector: `0xf19d48d1` - first 4 bytes of `blake2b_256("PSP34Metadata::get_attri
   "payable": false,
   "returnType": {
     "displayName": [
-      "Option"
+      "ink",
+      "MessageResult"
     ],
     "type": "Option<[u8]>"
   },
@@ -412,8 +418,8 @@ Selector: `0x3bcfb511` - first 4 bytes of `blake2b_256("PSP34Enumerable::owners_
   "payable": false,
   "returnType": {
     "displayName": [
-      "psp34enumerable_external",
-      "OwnersTokenByIndexOutput"
+      "ink",
+      "MessageResult"
     ],
     "type": 26
   },
@@ -446,8 +452,8 @@ Selector: `0xcd0340d0` - first 4 bytes of `blake2b_256("PSP37Enumerable::owners_
   "payable": false,
   "returnType": {
     "displayName": [
-      "psp34enumerable_external",
-      "TokenByIndexOutput"
+      "ink",
+      "MessageResult"
     ],
     "type": 26
   },
@@ -491,7 +497,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
       "label": "id",
       "type": {
         "displayName": [
-           "Id"
+          "Id"
         ],
         "type": "Id"
       }
@@ -570,7 +576,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
       "label": "id",
       "type": {
         "displayName": [
-           "Id"
+          "Id"
         ],
         "type": "Id"
       }

--- a/PSPs/psp-37.md
+++ b/PSPs/psp-37.md
@@ -26,7 +26,7 @@ Examples of implementations:
 
 ## Motivation for having a standard separate from ERC-1155
 Due to the different nature of WebAssembly smart contracts and the difference between EVM and the [`contracts` pallet](https://github.com/paritytech/substrate/tree/master/frame/contracts) in Substrate, this standard proposal has specific rules and methods,
-therefore PSP-37 differs from ERC-1155 in its implementation. 
+therefore PSP-37 differs from ERC-1155 in its implementation.
 
 Also the proposal contains new:
 - types to keep interoperability with Fungible and Non-Fungible tokens standard defined in previous PSPs.
@@ -83,7 +83,8 @@ Selector: `0xc42919e2` - first 4 bytes of `blake2b_256("PSP37::balance_of")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Balance"
+      "ink",
+      "MessageResult"
     ],
     "type": "Balance"
   },
@@ -116,7 +117,8 @@ Selector: `0x9a49e85a` - first 4 bytes of `blake2b_256("PSP37::total_supply")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Balance"
+      "ink",
+      "MessageResult"
     ],
     "type": "Balance"
   },
@@ -166,7 +168,8 @@ Selector: `0xcb78a065` - first 4 bytes of `blake2b_256("PSP37::allowance")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Balance"
+      "ink",
+      "MessageResult"
     ],
     "type": "Balance"
   },
@@ -220,7 +223,8 @@ Selector: `0x31a1a453` - first 4 bytes of `blake2b_256("PSP37::approve")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -290,7 +294,8 @@ Selector: `0x04e09961` - first 4 bytes of `blake2b_256("PSP37::transfer")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -369,7 +374,8 @@ Selector: `0x5cf8b7d4` - first 4 bytes of `blake2b_256("PSP37::transfer_from")`
   "payable": false,
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -413,7 +419,8 @@ Selector: `0x61dda97c` - first 4 bytes of `blake2b_256("PSP37Metadata::get_attri
   "payable": false,
   "returnType": {
     "displayName": [
-      "Option"
+      "ink",
+      "MessageResult"
     ],
     "type": "Option<[u8]>"
   },
@@ -469,7 +476,8 @@ Selector: `0x9bfb1d2b` - first 4 bytes of `blake2b_256("PSP37Batch::batch_transf
   "payable": false,
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -525,7 +533,8 @@ Selector: `0xf4ebeed2` - first 4 bytes of `blake2b_256("PSP37Batch::batch_transf
   "payable": false,
   "returnType": {
     "displayName": [
-      "Result"
+      "ink",
+      "MessageResult"
     ],
     "type": 1
   },
@@ -571,7 +580,8 @@ Selector: `0x4cc01ee0` - first 4 bytes of `blake2b_256("PSP37Enumerable::owners_
   "payable": false,
   "returnType": {
     "displayName": [
-      "Option"
+      "ink",
+      "MessageResult"
     ],
     "type": "Option<Id>"
   },
@@ -603,7 +613,8 @@ Selector: `0x127b5477` - first 4 bytes of `blake2b_256("PSP37Enumerable::token_b
   "payable": false,
   "returnType": {
     "displayName": [
-      "Option"
+      "ink",
+      "MessageResult"
     ],
     "type": "Option<Id>"
   },
@@ -647,7 +658,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
       "label": "id",
       "type": {
         "displayName": [
-           "Id"
+          "Id"
         ],
         "type": "Id"
       }
@@ -705,7 +716,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
       "label": "ids_amounts",
       "type": {
         "displayName": [
-           "[(Id, Balance)]"
+          "[(Id, Balance)]"
         ],
         "type": "[(Id, Balance)]"
       }
@@ -750,7 +761,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
       "label": "id",
       "type": {
         "displayName": [
-           "Option<Id>"
+          "Option<Id>"
         ],
         "type": "Option<Id>"
       }
@@ -784,7 +795,7 @@ When a contract deletes (burns) tokens, `to` will be `None`.
       "label": "id",
       "type": {
         "displayName": [
-           "Id"
+          "Id"
         ],
         "type": "Id"
       }


### PR DESCRIPTION
In new ink! versions every method's return type is now wrapped in MessageResult. This PR updates ABI's of PSPs due to this change.