### PR TITLE
fix: wrong description for `PSP34Enumerable::token_by_index` selector

### DIFF
--- a/PSPs/psp-34.md
+++ b/PSPs/psp-34.md
@@ -22,7 +22,8 @@ The goal is to have a standard contract interface that allows tokens deployed on
 ## Implementations
 Examples of implementations:
 
-- [OpenBrush](https://github.com/Brushfam/openbrush-contracts/blob/main/contracts/src/token/psp34/psp34.rs), written in [ink!](https://github.com/paritytech/ink).
+- [Implementation with the OpenBrush library](https://github.com/Brushfam/openbrush-contracts/blob/main/contracts/src/token/psp34/psp34.rs), written in [ink!](https://github.com/paritytech/ink).
+- [Implementation in pure ink!](https://github.com/Cardinal-Cryptography/PSP34]), by [Cardinal Cryptography](http://cardinal.co).
 
 ## Motivation for having a standard separate from ERC-721
 Due to the different nature of WebAssembly smart contracts and the difference between EVM and the [`contracts` pallet](https://github.com/paritytech/substrate/tree/master/frame/contracts) in Substrate, this standard proposal has specific rules and methods,
@@ -422,7 +423,7 @@ Selector: `0x3bcfb511` - first 4 bytes of `blake2b_256("PSP34Enumerable::owners_
 ```
 
 ##### **token_by_index**(index: u128) -> Option<Id>
-Selector: `0xcd0340d0` - first 4 bytes of `blake2b_256("PSP37Enumerable::owners_token_by_index")`
+Selector: `0xcd0340d0` - first 4 bytes of `blake2b_256("PSP34Enumerable::token_by_index")`
 ```json
 {
   "args": [

--- a/PSPs/psp-34.md
+++ b/PSPs/psp-34.md
@@ -22,8 +22,7 @@ The goal is to have a standard contract interface that allows tokens deployed on
 ## Implementations
 Examples of implementations:
 
-- [Implementation with the OpenBrush library](https://github.com/Brushfam/openbrush-contracts/blob/main/contracts/src/token/psp34/psp34.rs), written in [ink!](https://github.com/paritytech/ink).
-- [Implementation in pure ink!](https://github.com/Cardinal-Cryptography/PSP34]), by [Cardinal Cryptography](http://cardinal.co).
+- [OpenBrush](https://github.com/Brushfam/openbrush-contracts/blob/main/contracts/src/token/psp34/psp34.rs), written in [ink!](https://github.com/paritytech/ink).
 
 ## Motivation for having a standard separate from ERC-721
 Due to the different nature of WebAssembly smart contracts and the difference between EVM and the [`contracts` pallet](https://github.com/paritytech/substrate/tree/master/frame/contracts) in Substrate, this standard proposal has specific rules and methods,


### PR DESCRIPTION
Just notice that the description for token_by_index function selector is completely wrong.